### PR TITLE
fix: noun declension code

### DIFF
--- a/cmd/protoc-gen-openapi/examples/tests/pathparams/message.proto
+++ b/cmd/protoc-gen-openapi/examples/tests/pathparams/message.proto
@@ -40,6 +40,13 @@ service Messaging {
       body : "*"
     };
   }
+
+  // Test irregular plural: series/* should stay as {series}, not {serie}
+  rpc GetMessageSeries(GetMessageSeriesRequest) returns (MessageSeries) {
+    option (google.api.http) = {
+      get : "/v1/{name=series/*}"
+    };
+  }
 }
 
 message GetMessageRequest {
@@ -64,4 +71,14 @@ message Comment {
   string comment_id = 1;
   uint64 user_id = 2;
   string content = 3;
+}
+
+message MessageSeries {
+  string name = 1;
+  string description = 2;
+  repeated Message messages = 3;
+}
+
+message GetMessageSeriesRequest {
+  string name = 1;
 }

--- a/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi.yaml
@@ -63,6 +63,32 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/Status'
+    /v1/series/{series}:
+        get:
+            tags:
+                - Messaging
+            description: 'Test irregular plural: series/* should stay as {series}, not {serie}'
+            operationId: Messaging_GetMessageSeries
+            parameters:
+                - name: series
+                  in: path
+                  description: The series id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/MessageSeries'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
     /v1/users/{user_id}/messages/{message_id}:
         get:
             tags:
@@ -113,6 +139,17 @@ components:
                     type: string
                 maybe:
                     type: string
+        MessageSeries:
+            type: object
+            properties:
+                name:
+                    type: string
+                description:
+                    type: string
+                messages:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Message'
         Status:
             type: object
             properties:

--- a/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi_default_response.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi_default_response.yaml
@@ -63,6 +63,32 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/Status'
+    /v1/series/{series}:
+        get:
+            tags:
+                - Messaging
+            description: 'Test irregular plural: series/* should stay as {series}, not {serie}'
+            operationId: Messaging_GetMessageSeries
+            parameters:
+                - name: series
+                  in: path
+                  description: The series id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/MessageSeries'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
     /v1/users/{userId}/messages/{messageId}:
         get:
             tags:
@@ -113,6 +139,17 @@ components:
                     type: string
                 maybe:
                     type: string
+        MessageSeries:
+            type: object
+            properties:
+                name:
+                    type: string
+                description:
+                    type: string
+                messages:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Message'
         Status:
             type: object
             properties:

--- a/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi_fq_schema_naming.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi_fq_schema_naming.yaml
@@ -63,6 +63,32 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/google.rpc.Status'
+    /v1/series/{series}:
+        get:
+            tags:
+                - Messaging
+            description: 'Test irregular plural: series/* should stay as {series}, not {serie}'
+            operationId: Messaging_GetMessageSeries
+            parameters:
+                - name: series
+                  in: path
+                  description: The series id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/tests.pathparams.message.v1.MessageSeries'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/google.rpc.Status'
     /v1/users/{userId}/messages/{messageId}:
         get:
             tags:
@@ -129,5 +155,16 @@ components:
                     type: string
                 maybe:
                     type: string
+        tests.pathparams.message.v1.MessageSeries:
+            type: object
+            properties:
+                name:
+                    type: string
+                description:
+                    type: string
+                messages:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/tests.pathparams.message.v1.Message'
 tags:
     - name: Messaging

--- a/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi_json.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi_json.yaml
@@ -63,6 +63,32 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/Status'
+    /v1/series/{series}:
+        get:
+            tags:
+                - Messaging
+            description: 'Test irregular plural: series/* should stay as {series}, not {serie}'
+            operationId: Messaging_GetMessageSeries
+            parameters:
+                - name: series
+                  in: path
+                  description: The series id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/MessageSeries'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
     /v1/users/{userId}/messages/{messageId}:
         get:
             tags:
@@ -113,6 +139,17 @@ components:
                     type: string
                 maybe:
                     type: string
+        MessageSeries:
+            type: object
+            properties:
+                name:
+                    type: string
+                description:
+                    type: string
+                messages:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Message'
         Status:
             type: object
             properties:

--- a/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi_string_enum.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi_string_enum.yaml
@@ -63,6 +63,32 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/Status'
+    /v1/series/{series}:
+        get:
+            tags:
+                - Messaging
+            description: 'Test irregular plural: series/* should stay as {series}, not {serie}'
+            operationId: Messaging_GetMessageSeries
+            parameters:
+                - name: series
+                  in: path
+                  description: The series id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/MessageSeries'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
     /v1/users/{userId}/messages/{messageId}:
         get:
             tags:
@@ -113,6 +139,17 @@ components:
                     type: string
                 maybe:
                     type: string
+        MessageSeries:
+            type: object
+            properties:
+                name:
+                    type: string
+                description:
+                    type: string
+                messages:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Message'
         Status:
             type: object
             properties:

--- a/cmd/protoc-gen-openapi/generator/utils.go
+++ b/cmd/protoc-gen-openapi/generator/utils.go
@@ -16,9 +16,9 @@
 package generator
 
 import (
-	"strings"
-
 	"google.golang.org/protobuf/reflect/protoreflect"
+
+	"github.com/jinzhu/inflection"
 )
 
 // contains returns true if an array contains a specified string.
@@ -41,16 +41,7 @@ func appendUnique(s []string, e string) []string {
 
 // singular produces the singular form of a collection name.
 func singular(plural string) string {
-	if strings.HasSuffix(plural, "ves") {
-		return strings.TrimSuffix(plural, "ves") + "f"
-	}
-	if strings.HasSuffix(plural, "ies") {
-		return strings.TrimSuffix(plural, "ies") + "y"
-	}
-	if strings.HasSuffix(plural, "s") {
-		return strings.TrimSuffix(plural, "s")
-	}
-	return plural
+	return inflection.Singular(plural)
 }
 
 func getValueKind(message protoreflect.MessageDescriptor) string {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/golang/protobuf v1.5.4
 	github.com/google/gnostic-models v0.7.0
 	github.com/google/go-cmp v0.6.0
+	github.com/jinzhu/inflection v1.0.0
 	github.com/stoewer/go-strcase v1.3.1
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/tools v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/google/gnostic-models v0.7.0 h1:qwTtogB15McXDaNqTZdzPJRHvaVJlAl+HVQnL
 github.com/google/gnostic-models v0.7.0/go.mod h1:whL5G0m6dmc5cPxKc5bdKdEN3UjI7OUGxBlw57miDrQ=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
+github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stoewer/go-strcase v1.3.1 h1:iS0MdW+kVTxgMoE1LAZyMiYJFKlOzLooE4MxjirtkAs=


### PR DESCRIPTION
- old code was very basic, didn't account for uninflected words and less-common declension like "addresses" -> "address"
- this is a good candidate for a dedicated dependency, and jinzhu/inflection has no deps.