### PR TITLE
promote body field description to templated path parameters

### DIFF
--- a/cmd/protoc-gen-openapi/generator/generator.go
+++ b/cmd/protoc-gen-openapi/generator/generator.go
@@ -520,6 +520,14 @@ func (g *OpenAPIv3Generator) buildOperationV3(
 
 		// Add the named path parameters to the operation parameters.
 		for _, namedPathParameter := range namedPathParameters {
+			var fieldDescription string
+			field := g.findField(namedPathParameter, inputMessage)
+			if field != nil {
+				fieldDescription = g.filterCommentString(field.Comments.Leading)
+			}
+			if fieldDescription == "" {
+				fieldDescription = "The " + namedPathParameter + " id."
+			}
 			parameters = append(parameters,
 				&v3.ParameterOrReference{
 					Oneof: &v3.ParameterOrReference_Parameter{
@@ -527,7 +535,7 @@ func (g *OpenAPIv3Generator) buildOperationV3(
 							Name:        namedPathParameter,
 							In:          "path",
 							Required:    true,
-							Description: "The " + namedPathParameter + " id.",
+							Description: fieldDescription,
 							Schema: &v3.SchemaOrReference{
 								Oneof: &v3.SchemaOrReference_Schema{
 									Schema: &v3.Schema{


### PR DESCRIPTION
RPCs using the `google.api.http` annotation can provide simple bindings like `{name}` , or templated bindings like `{name=a/b/*}`. For the former, Gnostic will copy the matching field description from the request body to the parameter, however the latter always gets a generic `The <field> Id.` description.

This PR allows templated bindings to receive the field description as well, if it is present. Otherwise, it will fall back to the original generic description.