### PR TITLE
extend openapi.v3.path_param_hints exmaples

### DIFF
--- a/cmd/protoc-gen-openapi/examples/tests/pathparamhints/message.proto
+++ b/cmd/protoc-gen-openapi/examples/tests/pathparamhints/message.proto
@@ -49,8 +49,28 @@ service Library {
       hint: {
         name: "book"
         description: "The book's ISBN."
-        example: "isbn-123"
-        example: "isbn-456"
+        examples: {name: "isbn example 1" value: "isbn-123" }
+        examples: {name: "isbn example 2" value: "isbn-456" description: "example2 description"}
+      }
+    };
+  }
+  // Get a book by its resource name (v2)
+  rpc GetBookv2(GetBookRequest) returns (Book) {
+    option (google.api.http) = {get: "/v2/{name=publishers/*/books/*}"};
+    option (openapi.v3.path_param_hints) = {
+      hint: {
+        name: "publisher"
+        description: "The unique publisher identifier."
+        example: "2"
+        examples: {name: "publisher named example" value: "3" description:"another example" } // overridden, will warn, but not appear
+      }
+      hint: {
+        name: "book"
+        description: "The book's ISBN."
+        examples: {name: "isbn example 1" value: "isbn-100" description: "isbn example 1" }
+        examples: {value: "isbn-200" description: "isbn example 2" } // no name, skipped
+        examples: {name: "isbn example 3" description: "isbn example 3" } // no value, skipped
+        examples: {name: "isbn example 4" value: "isbn-400" description: "isbn example 4" }
       }
     };
   }

--- a/cmd/protoc-gen-openapi/examples/tests/pathparamhints/openapi.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/pathparamhints/openapi.yaml
@@ -28,10 +28,51 @@ paths:
                   schema:
                     type: string
                   examples:
-                    example1:
+                    isbn example 1:
                         value: isbn-123
-                    example2:
+                    isbn example 2:
+                        description: example2 description
                         value: isbn-456
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Book'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v2/publishers/{publisher}/books/{book}:
+        get:
+            tags:
+                - Library
+            description: Get a book by its resource name (v2)
+            operationId: Library_GetBookv2
+            parameters:
+                - name: publisher
+                  in: path
+                  description: The unique publisher identifier.
+                  required: true
+                  schema:
+                    type: string
+                  example: 2
+                - name: book
+                  in: path
+                  description: The book's ISBN.
+                  required: true
+                  schema:
+                    type: string
+                  examples:
+                    isbn example 1:
+                        description: isbn example 1
+                        value: isbn-100
+                    isbn example 4:
+                        description: isbn example 4
+                        value: isbn-400
             responses:
                 "200":
                     description: OK

--- a/go.mod
+++ b/go.mod
@@ -26,4 +26,4 @@ require (
 	golang.org/x/text v0.28.0 // indirect
 )
 
-replace github.com/google/gnostic-models => github.com/stairwell-inc/gnostic-models v0.0.0-20260122020652-90f065019624
+replace github.com/google/gnostic-models => github.com/stairwell-inc/gnostic-models v0.2.0-swell

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/pkg/diff v0.0.0-20241224192749-4e6772a4315c h1:8TRxBMS/YsupXoOiGKHr9Z
 github.com/pkg/diff v0.0.0-20241224192749-4e6772a4315c/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stairwell-inc/gnostic-models v0.0.0-20260122020652-90f065019624 h1:fUUxYEsXq5bAbAoZT1XVT2bKg5qX3OEjLIHE0FOtALw=
-github.com/stairwell-inc/gnostic-models v0.0.0-20260122020652-90f065019624/go.mod h1:whL5G0m6dmc5cPxKc5bdKdEN3UjI7OUGxBlw57miDrQ=
+github.com/stairwell-inc/gnostic-models v0.2.0-swell h1:7eWPZNCeLquS+wFilPhP9GubDoxRHGBAjnF/nP5HhwI=
+github.com/stairwell-inc/gnostic-models v0.2.0-swell/go.mod h1:whL5G0m6dmc5cPxKc5bdKdEN3UjI7OUGxBlw57miDrQ=
 github.com/stoewer/go-strcase v1.3.1 h1:iS0MdW+kVTxgMoE1LAZyMiYJFKlOzLooE4MxjirtkAs=
 github.com/stoewer/go-strcase v1.3.1/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8wodgtPmh1xo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/openapiv3/annotations.pbalias.go
+++ b/openapiv3/annotations.pbalias.go
@@ -19,8 +19,9 @@ import (
 )
 
 type (
-	PathParamHint  = openapiv3.PathParamHint
-	PathParamHints = openapiv3.PathParamHints
+	PathParamHint    = openapiv3.PathParamHint
+	PathParamHints   = openapiv3.PathParamHints
+	PathParamExample = openapiv3.PathParamExample
 )
 
 var (

--- a/openapiv3/annotations.proto
+++ b/openapiv3/annotations.proto
@@ -16,32 +16,28 @@ syntax = "proto3";
 
 package openapi.v3;
 
-import "openapiv3/OpenAPIv3.proto";
 import "google/protobuf/descriptor.proto";
+import "openapiv3/OpenAPIv3.proto";
 
+// The Go package name.
+option go_package = "github.com/google/gnostic-models/openapiv3;openapi_v3";
 // This option lets the proto compiler generate Java code inside the package
 // name (see below) instead of inside an outer class. It creates a simpler
 // developer experience by reducing one-level of name nesting and be
 // consistent with most programming languages that don't support outer classes.
 option java_multiple_files = true;
-
 // The Java outer classname should be the filename in UpperCamelCase. This
 // class is only used to hold proto descriptor, so developers don't need to
 // work with it directly.
 option java_outer_classname = "AnnotationsProto";
-
 // The Java package name must be proto package name with proper prefix.
 option java_package = "org.openapi_v3";
-
 // A reasonable prefix for the Objective-C symbols generated from the package.
 // It should at a minimum be 3 characters long, all uppercase, and convention
 // is to use an abbreviation of the package name. Something short, but
 // hopefully unique enough to not conflict with things that may come along in
 // the future. 'GPB' is reserved for the protocol buffer implementation itself.
 option objc_class_prefix = "OAS";
-
-// The Go package name.
-option go_package = "github.com/google/gnostic/openapiv3;openapi_v3";
 
 extend google.protobuf.FileOptions {
   Document document = 1143;
@@ -54,19 +50,33 @@ extend google.protobuf.FileOptions {
 //   '/v1/{name=publishers/*/books/*}'
 // where protoc-gen-openapi generates path parameter names by
 // replacing the wildcards with the singular form of the segment before it
-// (e.g. '/v1/publishers/{publisher}/books{book}').
+// (e.g. '/v1/publishers/{publisher}/books/{book}').
 // By default, these path parameters receive a generic description such as
 // 'The publisher id', which can be overridden with this option.
 message PathParamHint {
+  // The generated singular parameter name (e.g. 'book')
   string name = 1;
+  // The value for the OpenAPI 'description' field (e.g.: 'The ISBN number')
   string description = 2;
-  // Example values for this parameter. A single example will populate the
-  // "example" field in OpenAPI; multiple examples will populate "examples".
-  repeated string example = 3;
+  // Optional example value. If provided, overrides "examples"
+  string example = 3;
+  // Multiple examples. If provided, "example" must be empty.
+  repeated PathParamExample examples = 4;
 }
 
 message PathParamHints {
   repeated PathParamHint hint = 1;
+}
+
+// A named example for a path parameter, used when multiple examples are needed.
+// Maps to an entry in the OpenAPI 'examples' object.
+message PathParamExample {
+  // The name of the example case (required).
+  string name = 1;
+  // The value of this example (required).
+  string value = 2;
+  // Optional extended description for this specific example.
+  string description = 3;
 }
 
 extend google.protobuf.MethodOptions {


### PR DESCRIPTION
- now accepts either `example` (singular, basic scalar) or `examples` (multiple, with name/value/description)

dovetails with stairwell-inc/gnostic-models#3