### PR TITLE
protoc-gen-openapi: skip openapi.v3.* messages during schema emission

### DIFF
--- a/cmd/protoc-gen-openapi/examples/tests/openapiv3annotationleak/message.proto
+++ b/cmd/protoc-gen-openapi/examples/tests/openapiv3annotationleak/message.proto
@@ -1,0 +1,58 @@
+// Copyright 2026 Stairwell, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Regression fixture for schema-name collisions between user messages
+// and openapi.v3 annotation types. Uses naming=json (the default in
+// the tests) and defines a user message whose short name -- Tag --
+// collides with openapi.v3.Tag. Every RPC carries an
+// option (openapi.v3.operation) annotation to exercise the code path
+// that pulls openapi.v3.* messages into the plugin's file set.
+//
+// Expected output: components.schemas.Tag must be the user's Tag
+// (fields: name, value), NOT openapi.v3.Tag (fields: name,
+// description, externalDocs, specificationExtension). None of the
+// openapi.v3 helper types (Any, ExternalDocs, NamedAny) should appear
+// in components.schemas either.
+
+syntax = "proto3";
+
+package tests.openapiv3annotationleak.message.v1;
+
+import "google/api/annotations.proto";
+import "openapiv3/annotations.proto";
+
+option go_package = "github.com/google/gnostic/apps/protoc-gen-openapi/examples/tests/openapiv3annotationleak/message/v1;message";
+
+// User-defined Tag. Deliberately collides in short-name space with
+// openapi.v3.Tag.
+message Tag {
+  string name = 1;
+  string value = 2;
+}
+
+message ListTagsResponse {
+  repeated Tag tags = 1;
+}
+
+service TagService {
+  rpc GetTag(Tag) returns (Tag) {
+    option (google.api.http) = {get: "/v1/tags/{name}"};
+    option (openapi.v3.operation) = {summary: "GetTag"};
+  }
+  rpc ListTags(Tag) returns (ListTagsResponse) {
+    option (google.api.http) = {get: "/v1/tags"};
+    option (openapi.v3.operation) = {summary: "ListTags"};
+  }
+  rpc CreateTag(Tag) returns (Tag) {
+    option (google.api.http) = {
+      post: "/v1/tags"
+      body: "*"
+    };
+    option (openapi.v3.operation) = {summary: "CreateTag"};
+  }
+}

--- a/cmd/protoc-gen-openapi/examples/tests/openapiv3annotationleak/openapi.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/openapiv3annotationleak/openapi.yaml
@@ -1,0 +1,134 @@
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: TagService API
+    version: 0.0.1
+paths:
+    /v1/tags:
+        get:
+            tags:
+                - TagService
+            summary: ListTags
+            operationId: TagService_ListTags
+            parameters:
+                - name: name
+                  in: query
+                  schema:
+                    type: string
+                - name: value
+                  in: query
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ListTagsResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        post:
+            tags:
+                - TagService
+            summary: CreateTag
+            operationId: TagService_CreateTag
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Tag'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Tag'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/tags/{name}:
+        get:
+            tags:
+                - TagService
+            summary: GetTag
+            operationId: TagService_GetTag
+            parameters:
+                - name: name
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                - name: value
+                  in: query
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Tag'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+components:
+    schemas:
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        ListTagsResponse:
+            type: object
+            properties:
+                tags:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Tag'
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
+        Tag:
+            type: object
+            properties:
+                name:
+                    type: string
+                value:
+                    type: string
+            description: |-
+                User-defined Tag. Deliberately collides in short-name space with
+                 openapi.v3.Tag.
+tags:
+    - name: TagService

--- a/cmd/protoc-gen-openapi/generator/generator.go
+++ b/cmd/protoc-gen-openapi/generator/generator.go
@@ -50,6 +50,12 @@ type Configuration struct {
 
 const (
 	infoURL = "https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi"
+
+	// openAPIv3Package is the proto package of this generator's own
+	// annotation types. Messages in this package are option-carriers
+	// (e.g. v3.Operation, v3.Tag) and must never be emitted as entries
+	// in components.schemas of the generated document.
+	openAPIv3Package = "openapi.v3"
 )
 
 // In order to dynamically add google.rpc.Status responses we need
@@ -137,6 +143,16 @@ func (g *OpenAPIv3Generator) buildDocumentV3() *v3.Document {
 	for len(g.reflect.requiredSchemas) > 0 {
 		count := len(g.reflect.requiredSchemas)
 		for _, file := range g.plugin.Files {
+			// Skip the openapi.v3 annotation types. They exist only to
+			// decorate proto options (MethodOptions, MessageOptions, etc.)
+			// and are never a legitimate part of an API surface, so they
+			// must not appear in components.schemas. Without this guard,
+			// short-name schemas (naming=json) like "Tag" can collide
+			// with user messages of the same short name; whichever file
+			// is iterated first wins and the other is silently dropped.
+			if file.Desc.Package() == openAPIv3Package {
+				continue
+			}
 			g.addSchemasForMessagesToDocumentV3(d, file.Messages)
 		}
 		g.reflect.requiredSchemas = g.reflect.requiredSchemas[count:len(g.reflect.requiredSchemas)]

--- a/cmd/protoc-gen-openapi/plugin_test.go
+++ b/cmd/protoc-gen-openapi/plugin_test.go
@@ -44,6 +44,7 @@ func TestGenOpenAPI(t *testing.T) {
 	fixtureTest(t, "map fields", "examples/tests/mapfields/message.proto")
 	fixtureTest(t, "skip unannotated services", "examples/tests/noannotations/message.proto")
 	fixtureTest(t, "openapiv3annotations", "examples/tests/openapiv3annotations/message.proto")
+	fixtureTest(t, "openapiv3annotationleak", "examples/tests/openapiv3annotationleak/message.proto")
 	fixtureTest(t, "path parameters", "examples/tests/pathparams/message.proto")
 	fixtureTest(t, "path param hints", "examples/tests/pathparamhints/message.proto")
 	fixtureTest(t, "protobuf types", "examples/tests/protobuftypes/message.proto")


### PR DESCRIPTION
## Problem

`cmd/protoc-gen-openapi`'s schema-emission loop iterates over every proto file loaded by the plugin (generator.go:137-143) and short-circuits when a schema name is already emitted (addSchemaToDocumentV3, generator.go:999-1005). With `naming=json` (short names), this means the first file whose messages include a given short name wins the schema definition for that name.

The `openapi.v3` annotation types (`Tag`, `Operation`, `ExternalDocs`, `NamedAny`, `Any`, …) exist only to decorate proto options — `MethodOptions`, `MessageOptions`, `FieldOptions`, `FileOptions`. They are never a legitimate part of an API surface. But they are still iterated alongside user files during emission, so a user message whose short name collides with one of them (e.g. a user-defined `Tag`) can be **silently dropped** in favor of the annotation type. The user's RPC responses still reference `#/components/schemas/Tag`, but the schema definition at that anchor is now `openapi.v3.Tag` with fields `name`, `description`, `externalDocs`, `specificationExtension` — not the user's fields.

Which type wins depends on `protogen.Plugin.Files` iteration order, which is derived from the build-graph topological closure, not from the explicit proto list passed to protoc. Downstream users can accidentally flip the outcome just by adding an `openapi.v3.operation` annotation to a different proto file — that shifts the import graph enough to change iteration order. We hit this at Stairwell: a prior BUILD-level workaround ("list `openapi_proto` last in the protos list") happened to work for the import graph at write-time but was never causally correct. When a contributor added a new annotation elsewhere, the order flipped and dozens of generated SDK structs silently lost their fields.

## Fix

Skip files whose package is `openapi.v3` during the schema-emission loop:

```go
for _, file := range g.plugin.Files {
    if file.Desc.Package() == openAPIv3Package {
        continue
    }
    g.addSchemasForMessagesToDocumentV3(d, file.Messages)
}
```

These types are never a legitimate output schema, so excluding them is safe and correct. It also eliminates the order-dependence entirely — the collision cannot happen regardless of how the plugin orders its files.

## Regression fixture

`examples/tests/openapiv3annotationleak`. Defines a user-level `Tag` message (fields `name`, `value`) that collides in short-name space with `openapi.v3.Tag`, and exercises the code path that pulls openapi.v3 types into the plugin's file set — every RPC carries an `openapi.v3.operation` annotation. Golden yaml asserts that the user's `Tag` wins and none of the openapi.v3 helper types (`Any`, `ExternalDocs`, `NamedAny`) leak into `components.schemas`.

Verified locally that reverting the guard re-introduces the leak and the golden test fails with a diff showing the openapi.v3.Tag schema and the three helper types appearing.

## Test plan

- [x] `go test ./cmd/protoc-gen-openapi/...` — all existing fixtures unchanged.
- [x] New `openapiv3annotationleak` fixture passes with the fix.
- [x] Verified the new fixture **fails** without the fix (catches the regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)