### PR TITLE
protoc-gen-openapi: skip well-known annotation packages during schema emission

### DIFF
--- a/cmd/protoc-gen-openapi/examples/tests/openapiv3annotationleak/message.proto
+++ b/cmd/protoc-gen-openapi/examples/tests/openapiv3annotationleak/message.proto
@@ -1,0 +1,65 @@
+// Copyright 2021 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Regression fixture for schema-name collisions between user messages
+// and openapi.v3 annotation types. Uses naming=json (the default in
+// the tests) and defines a user message whose short name -- Tag --
+// collides with openapi.v3.Tag. Every RPC carries an
+// option (openapi.v3.operation) annotation to exercise the code path
+// that pulls openapi.v3.* messages into the plugin's file set.
+//
+// Expected output: components.schemas.Tag must be the user's Tag
+// (fields: name, value), NOT openapi.v3.Tag (fields: name,
+// description, externalDocs, specificationExtension). None of the
+// openapi.v3 helper types (Any, ExternalDocs, NamedAny) should appear
+// in components.schemas either.
+
+syntax = "proto3";
+
+package tests.openapiv3annotationleak.message.v1;
+
+import "google/api/annotations.proto";
+import "openapiv3/annotations.proto";
+
+option go_package = "github.com/google/gnostic/apps/protoc-gen-openapi/examples/tests/openapiv3annotationleak/message/v1;message";
+
+// User-defined Tag. Deliberately collides in short-name space with
+// openapi.v3.Tag.
+message Tag {
+  string name = 1;
+  string value = 2;
+}
+
+message ListTagsResponse {
+  repeated Tag tags = 1;
+}
+
+service TagService {
+  rpc GetTag(Tag) returns (Tag) {
+    option (google.api.http) = {get: "/v1/tags/{name}"};
+    option (openapi.v3.operation) = {summary: "GetTag"};
+  }
+  rpc ListTags(Tag) returns (ListTagsResponse) {
+    option (google.api.http) = {get: "/v1/tags"};
+    option (openapi.v3.operation) = {summary: "ListTags"};
+  }
+  rpc CreateTag(Tag) returns (Tag) {
+    option (google.api.http) = {
+      post: "/v1/tags"
+      body: "*"
+    };
+    option (openapi.v3.operation) = {summary: "CreateTag"};
+  }
+}

--- a/cmd/protoc-gen-openapi/examples/tests/openapiv3annotationleak/openapi.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/openapiv3annotationleak/openapi.yaml
@@ -1,0 +1,134 @@
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: TagService API
+    version: 0.0.1
+paths:
+    /v1/tags:
+        get:
+            tags:
+                - TagService
+            summary: ListTags
+            operationId: TagService_ListTags
+            parameters:
+                - name: name
+                  in: query
+                  schema:
+                    type: string
+                - name: value
+                  in: query
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ListTagsResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        post:
+            tags:
+                - TagService
+            summary: CreateTag
+            operationId: TagService_CreateTag
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Tag'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Tag'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/tags/{name}:
+        get:
+            tags:
+                - TagService
+            summary: GetTag
+            operationId: TagService_GetTag
+            parameters:
+                - name: name
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                - name: value
+                  in: query
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Tag'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+components:
+    schemas:
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        ListTagsResponse:
+            type: object
+            properties:
+                tags:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Tag'
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
+        Tag:
+            type: object
+            properties:
+                name:
+                    type: string
+                value:
+                    type: string
+            description: |-
+                User-defined Tag. Deliberately collides in short-name space with
+                 openapi.v3.Tag.
+tags:
+    - name: TagService

--- a/cmd/protoc-gen-openapi/generator/generator.go
+++ b/cmd/protoc-gen-openapi/generator/generator.go
@@ -53,9 +53,9 @@ const infoURL = "https://github.com/google/gnostic/tree/master/cmd/protoc-gen-op
 // wellknownAnnotationPackages lists proto packages whose messages are
 // option-carriers (e.g. openapi.v3.Operation, openapi.v3.Tag) and must
 // never be emitted as entries in components/schemas.
-var wellknownAnnotationPackages = map[string]struct{}{
-	"openapi.v3": {},
-}
+var wellknownAnnotationPackages = newNameSet(
+	"openapi.v3",
+)
 
 // In order to dynamically add google.rpc.Status responses we need
 // to know the message descriptors for google.rpc.Status as well
@@ -142,7 +142,7 @@ func (g *OpenAPIv3Generator) buildDocumentV3() *v3.Document {
 	for len(g.reflect.requiredSchemas) > 0 {
 		count := len(g.reflect.requiredSchemas)
 		for _, file := range g.plugin.Files {
-			if _, ok := wellknownAnnotationPackages[string(file.Desc.Package())]; ok {
+			if wellknownAnnotationPackages.Contains(file.Desc.Package()) {
 				continue
 			}
 			g.addSchemasForMessagesToDocumentV3(d, file.Messages)

--- a/cmd/protoc-gen-openapi/generator/generator.go
+++ b/cmd/protoc-gen-openapi/generator/generator.go
@@ -48,9 +48,14 @@ type Configuration struct {
 	WildcardBodyDedup *bool
 }
 
-const (
-	infoURL = "https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi"
-)
+const infoURL = "https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi"
+
+// wellknownAnnotationPackages lists proto packages whose messages are
+// option-carriers (e.g. openapi.v3.Operation, openapi.v3.Tag) and must
+// never be emitted as entries in components/schemas.
+var wellknownAnnotationPackages = map[string]struct{}{
+	"openapi.v3": {},
+}
 
 // In order to dynamically add google.rpc.Status responses we need
 // to know the message descriptors for google.rpc.Status as well
@@ -137,6 +142,9 @@ func (g *OpenAPIv3Generator) buildDocumentV3() *v3.Document {
 	for len(g.reflect.requiredSchemas) > 0 {
 		count := len(g.reflect.requiredSchemas)
 		for _, file := range g.plugin.Files {
+			if _, ok := wellknownAnnotationPackages[string(file.Desc.Package())]; ok {
+				continue
+			}
 			g.addSchemasForMessagesToDocumentV3(d, file.Messages)
 		}
 		g.reflect.requiredSchemas = g.reflect.requiredSchemas[count:len(g.reflect.requiredSchemas)]

--- a/cmd/protoc-gen-openapi/generator/utils.go
+++ b/cmd/protoc-gen-openapi/generator/utils.go
@@ -53,3 +53,20 @@ func getValueField(message protoreflect.MessageDescriptor) protoreflect.FieldDes
 	fields := message.Fields()
 	return fields.ByName("value")
 }
+
+type nameSet struct {
+	m map[string]struct{}
+}
+
+func newNameSet(names ...string) *nameSet {
+	m := map[string]struct{}{}
+	for _, name := range names {
+		m[name] = struct{}{}
+	}
+	return &nameSet{m: m}
+}
+
+func (s *nameSet) Contains(name protoreflect.FullName) bool {
+	_, found := s.m[string(name)]
+	return found
+}

--- a/cmd/protoc-gen-openapi/plugin_test.go
+++ b/cmd/protoc-gen-openapi/plugin_test.go
@@ -44,6 +44,7 @@ func TestGenOpenAPI(t *testing.T) {
 	fixtureTest(t, "map fields", "examples/tests/mapfields/message.proto")
 	fixtureTest(t, "skip unannotated services", "examples/tests/noannotations/message.proto")
 	fixtureTest(t, "openapiv3annotations", "examples/tests/openapiv3annotations/message.proto")
+	fixtureTest(t, "openapiv3annotationleak", "examples/tests/openapiv3annotationleak/message.proto")
 	fixtureTest(t, "path parameters", "examples/tests/pathparams/message.proto")
 	fixtureTest(t, "path param hints", "examples/tests/pathparamhints/message.proto")
 	fixtureTest(t, "protobuf types", "examples/tests/protobuftypes/message.proto")


### PR DESCRIPTION
## Summary

- Annotation types from packages like `openapi.v3` (e.g. `Tag`, `Operation`) are option-carriers that should never appear in `components/schemas`. With short naming modes, their names can collide with user-defined messages, causing user schemas to be silently dropped.
- Adds an unexported package-level `wellknownAnnotationPackages` map to skip these packages during the schema-emission loop.
- Supersedes #12 — uses an extensible map rather than a single constant.

## Test plan

- [x] New `openapiv3annotationleak` fixture defines a user `Tag` message that collides with `openapi.v3.Tag`; golden YAML asserts the user's `Tag` wins
- [x] All existing fixture tests pass unchanged